### PR TITLE
moved conditional to check for empty text before checking range

### DIFF
--- a/plugins/NewSpring.share.coffee
+++ b/plugins/NewSpring.share.coffee
@@ -73,18 +73,19 @@ class Share
 
     selection = document.getSelection()
     text = selection.toString()
-    range = selection.getRangeAt(0).cloneRange()
-    boundary = range.getBoundingClientRect()
-    if range.getClientRects
-      range.collapse(true)
-      rec = range.getClientRects()[0];
-      y = rec.top;
-      top = document.body.scrollTop + y
-
-
-    rect = range.getClientRects()[0]
     el = document.getElementById("share")
+    
     unless text is ""
+    
+      range = selection.getRangeAt(0).cloneRange()
+      boundary = range.getBoundingClientRect()
+      if range.getClientRects
+        range.collapse(true)
+        rec = range.getClientRects()[0];      
+        y = rec.top;
+        top = document.body.scrollTop + y
+
+      rect = range.getClientRects()[0]
 
       core.addClass el, "share-menu-active"
       @_properties.text = text


### PR DESCRIPTION
Problem: original line 76 was causing error because DOM wasn't loaded. 

Fix: Moved the `unless text = ""` conditional before that line, since the only thing the function needs to do if the text is empty is remove the active class on the sharing popup.

Broken: on safari... https://newspring.cc/articles/3-simple-ways-to-get-the-best-rest
Fixed: on safari... http://beta.newspring.cc/articles/2-practical-lessons-a-christian-can-learn-from-football 
